### PR TITLE
Adds Semigroup (Vector u v c) instance to make compatible with GHC >= 8.4

### DIFF
--- a/hybrid-vectors.cabal
+++ b/hybrid-vectors.cabal
@@ -28,7 +28,8 @@ library
     base          >= 4       && < 5,
     deepseq       >= 1.1     && < 1.5,
     primitive     >= 0.5     && < 0.7,
-    vector        >= 0.10    && < 0.13
+    vector        >= 0.10    && < 0.13,
+    semigroups    >= 0.9     && < 1
 
   hs-source-dirs: src
 

--- a/src/Data/Vector/Hybrid/Internal.hs
+++ b/src/Data/Vector/Hybrid/Internal.hs
@@ -1,13 +1,7 @@
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE KindSignatures #-}
-{-# LANGUAGE GADTs #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE CPP, DeriveDataTypeable, FlexibleInstances, GADTs        #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving, KindSignatures               #-}
+{-# LANGUAGE MultiParamTypeClasses, ScopedTypeVariables, TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances                                     #-}
 
 #ifndef MIN_VERSION_base
 #define MIN_VERSION_base(x,y,z) 1
@@ -22,10 +16,12 @@ module Data.Vector.Hybrid.Internal
   , Vector(..)
   ) where
 
-import Control.Monad
-import Data.Monoid
+import           Control.Monad
+import qualified Data.Foldable               as F
+import           Data.Monoid
+import           Data.Semigroup
+import qualified Data.Vector.Generic         as G
 import qualified Data.Vector.Generic.Mutable as GM
-import qualified Data.Vector.Generic as G
 
 
 #if MIN_VERSION_vector(0,11,0)
@@ -35,7 +31,8 @@ import Data.Vector.Fusion.Stream as Stream
 #endif
 
 import Data.Data
-import Prelude hiding ( length, null, replicate, reverse, map, read, take, drop, init, tail )
+import Prelude   hiding (drop, init, length, map, null, read, replicate,
+                  reverse, tail, take)
 import Text.Read
 
 data MVector :: (* -> * -> *) -> (* -> * -> *) -> * -> * -> * where
@@ -141,6 +138,10 @@ instance (G.Vector u a, G.Vector v b) => G.Vector (Vector u v) (a, b) where
   {-# INLINE basicUnsafeCopy #-}
   elemseq (V ks vs) (k,v) b = G.elemseq ks k (G.elemseq vs v b)
   {-# INLINE elemseq #-}
+
+instance (G.Vector u a, G.Vector v b, c ~ (a, b)) => Semigroup (Vector u v c) where
+  (<>) = mappend
+  sconcat = mconcat . F.toList
 
 instance (G.Vector u a, G.Vector v b, c ~ (a, b)) => Monoid (Vector u v c) where
   mappend = (G.++)


### PR DESCRIPTION
From GHC 8.4, `Semigroup` becomes a part of `base` package and a superclass of `Monoid`.

This pull request adds  `Semigroup (Vector u v c)` and `semigroups` package to make `hybrid-vectors` compatible with GHC >= 8.4.