### PR TITLE
Bump primitive upper bound to < 0.10

### DIFF
--- a/hybrid-vectors.cabal
+++ b/hybrid-vectors.cabal
@@ -42,7 +42,7 @@ library
   build-depends:
     base          >= 4       && < 5,
     deepseq       >= 1.1     && < 1.6,
-    primitive     >= 0.5     && < 0.9,
+    primitive     >= 0.5     && < 0.10,
     vector        >= 0.10    && < 0.14,
     semigroups    >= 0.9     && < 1
 


### PR DESCRIPTION
Due to this: https://github.com/commercialhaskell/stackage/issues/7138

It builds fine without changes.